### PR TITLE
change overflow-y from scroll to auto

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -36,7 +36,7 @@ const modalContent = css`
   max-height: 90%;
   max-width: 800px;
   padding-bottom: 20px;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   ${mq.medium(css`
     width: 100%;


### PR DESCRIPTION
with "scroll" set, each modal shows a scrolling bar instead of only showing it when its necessary / scrollable