### PR TITLE
fixing the mod mail crash error

### DIFF
--- a/src/pages/Dashboard/modules/Moderation/index.js
+++ b/src/pages/Dashboard/modules/Moderation/index.js
@@ -279,7 +279,7 @@ class ModerationEditor extends Component {
                               Validation.numberMax(50)
                             )}
                           />
-                        </div>{" "}
+                        </div>
                         <div>
                           <HelpModal content={<HelpContent {...HelpText.modmail.maxPerGuild} />} />
                         </div>


### PR DESCRIPTION
This fixes the crash on Mod Mail Page when enabling the mod mails.

![image](https://user-images.githubusercontent.com/23035000/49034123-06ade380-f17f-11e8-9869-3108787ec04c.png)
