### PR TITLE
fixes the problem of serverlist containing null

### DIFF
--- a/src/pages/Login/ServerList.js
+++ b/src/pages/Login/ServerList.js
@@ -181,9 +181,9 @@ class ServerList extends React.Component {
           let me = data.me;
           let guilds = [
             // First those servers that we are the owner
-            ...me.serverList.filter(g => g.ownerId === me.id),
+            ...me.serverList.filter(g => g && g.ownerId === me.id),
             // Then those that we are just administrator
-            ...me.serverList.filter(g => g.ownerId !== me.id),
+            ...me.serverList.filter(g => g && g.ownerId !== me.id),
           ];
 
           if (value)


### PR DESCRIPTION
i tried to reproduce the error on local development but everything just worked fine.

bot is returning only servers that are existing. api is also checking for `.filter(Boolean)`. So at the moment this workaround fix needs to be done to solve the problem temporarily