### PR TITLE
disable non-vips from seeing special feature

### DIFF
--- a/src/pages/Dashboard/modules/Special Features/index.js
+++ b/src/pages/Dashboard/modules/Special Features/index.js
@@ -43,11 +43,9 @@ class SpecialFeatureEditor extends Component {
                   This page shows VIP features that are available to VIP servers. To become a VIP and unlock all these amazing features please become a patron.
                 </SubHeader>
               </section>
-              <br />
-              <br />
-              <br />
+
               <section>
-                <a href="https://patreon.com/g4m3r" target="_blank" rel="noopener noreferrer"><Button>Become A Patreon</Button></a>
+                <a href="https://patreon.com/g4m3r" target="_blank" rel="noopener noreferrer"><Button big>Become A Patreon</Button></a>
               </section>
             </React.Fragment>
           )


### PR DESCRIPTION
This PR should disable servers that are not VIP from accessing the VIP Special Feature page.

When VIP is not enabled

![image](https://user-images.githubusercontent.com/23035000/49121248-c7b28780-f27d-11e8-8105-3ec3603ef30a.png)


When VIP is enabled

![image](https://user-images.githubusercontent.com/23035000/49121491-97b7b400-f27e-11e8-91d9-ee0831107047.png)
