### PR TITLE
masking the placeholder

### DIFF
--- a/src/components/InputMask.js
+++ b/src/components/InputMask.js
@@ -22,7 +22,7 @@ export const Masks = {
     out: value => {
       if (isNaN(Number(value))) return 0;
       return value * 60000;
-    }
+    },
   },
   hoursToMs: {
     in: value => {
@@ -32,8 +32,8 @@ export const Masks = {
     out: value => {
       if (isNaN(Number(value))) return 0;
       return value * 36000000;
-    }
-  }
+    },
+  },
 };
 
 class InputMask extends React.Component {
@@ -51,7 +51,7 @@ class InputMask extends React.Component {
         // The order here matters. value and onChange can't be overwritten
         value={this.props.mask.in(this.props.value)}
         onChange={this.onChange}
-        placeholder={this.props.mask.in(this.props.placeholder)}
+        placeholder={this.props.placeholder && this.props.mask.in(this.props.placeholder)}
       />
     );
   }

--- a/src/components/InputMask.test.js
+++ b/src/components/InputMask.test.js
@@ -44,6 +44,27 @@ describe("InputMask", () => {
     expect(onChange).toHaveBeenCalled();
     expect(onChange).toHaveBeenCalledWith(exampleMask.out(event.target.value));
   });
+
+  it("masks the placeholder", () => {
+    const { getByLabelText } = render(
+      <InputMask mask={exampleMask} placeholder={10} aria-label="input-test" />
+    );
+
+    const input = getByLabelText("input-test");
+
+    // @fix: why string here? because "value" on the dom is always a string
+    expect(input.placeholder).toBe(String(exampleMask.in("10")));
+  });
+
+  it("works without placeholder", () => {
+    const { getByLabelText } = render(
+      <InputMask mask={exampleMask} aria-label="input-test" />
+    );
+
+    const input = getByLabelText("input-test");
+
+    expect(input.placeholder).toBe("");
+  });
 });
 
 describe("Input Masks Helpers", () => {


### PR DESCRIPTION
This PR will make sure that the placeholders on InputMasks are also masked properly. Currently, the placeholders are not being masked and if you remove the value it shows something like 5000 as opposed to just 5.

![image](https://user-images.githubusercontent.com/23035000/49690908-48874400-fb06-11e8-91fe-7996e554997b.png)


Closes #119